### PR TITLE
Fix team-soju#4134

### DIFF
--- a/src/Orangebeard.SpecFlowPlugin/Orangebeard.SpecFlowPlugin.csproj
+++ b/src/Orangebeard.SpecFlowPlugin/Orangebeard.SpecFlowPlugin.csproj
@@ -1,7 +1,7 @@
 <Project Sdk="Microsoft.NET.Sdk">
 
   <PropertyGroup>
-    <TargetFrameworks>net461;netstandard2.1;netcoreapp3.1</TargetFrameworks>
+    <TargetFrameworks>net462;netstandard2.1;netcoreapp3.1</TargetFrameworks>
     <PackageId>Orangebeard.SpecFlow</PackageId>
     <Version>1.0.0.3</Version>
     
@@ -23,7 +23,7 @@
   </PropertyGroup>
 
   <ItemGroup>
-    <PackageReference Include="Orangebeard.Client" Version="2.0.0.4" />
+    <PackageReference Include="Orangebeard.Client" Version="2.0.0.5" />
     <PackageReference Include="SpecFlow" Version="3.9.74" />
     <PackageReference Include="System.Collections" Version="4.3.0" />
   </ItemGroup>

--- a/src/Orangebeard.SpecFlowPlugin/OrangebeardHooks.cs
+++ b/src/Orangebeard.SpecFlowPlugin/OrangebeardHooks.cs
@@ -80,7 +80,7 @@ namespace Orangebeard.SpecFlowPlugin
                     OrangebeardAddIn.TestrunUuid = _testRunUuid;
                     if (_testRunUuid == null)
                     {
-                        _traceLogger.Error("Test run failed to start!");
+                        _traceLogger.Error("Orangebeard Test run failed to start! Did you use the right Endpoint/UUID/Project?");
                     }
                     else
                     {
@@ -198,7 +198,7 @@ namespace Orangebeard.SpecFlowPlugin
                         if (!eventArg.Canceled)
                         {
                             Context.Current = Context.Current.Parent;
-                            _client.FinishTestItem(_testRunUuid.Value, finishTestItem);
+                            _client.FinishTestItem(currentFeature.Value, finishTestItem);
 
                             OrangebeardAddIn.OnAfterFeatureFinished(null, new TestItemFinishedEventArgs(_client, finishTestItem, currentFeature.Value, featureContext, null));
                         }


### PR DESCRIPTION
Fixed a bug where the test run UUID was used instead of the suite UUID when finishing a feature/suite; 
Latest dotnet client (2.0.0.5);
Update .NetFW target to 4.6.2 (4.6.1 is eol)

