### PR TITLE
OutputHelper Support & Unique test cases

### DIFF
--- a/src/Orangebeard.SpecFlowPlugin/Attachment/SpecFlowAttachmentFile.cs
+++ b/src/Orangebeard.SpecFlowPlugin/Attachment/SpecFlowAttachmentFile.cs
@@ -1,0 +1,21 @@
+﻿using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Text;
+using System.Threading.Tasks;
+
+namespace Orangebeard.SpecFlowPlugin.Attachment
+{
+    internal class SpecFlowAttachmentFile
+    {
+        public string MimeType { get; }
+        public string FileName { get; }
+        public byte[] Data { get; }
+        public SpecFlowAttachmentFile(string mimeType, string fileName, byte[] data)
+        {
+            this.MimeType = mimeType;
+            this.FileName = fileName;
+            this.Data = data;
+        }   
+    }
+}

--- a/src/Orangebeard.SpecFlowPlugin/Orangebeard.SpecFlowPlugin.csproj
+++ b/src/Orangebeard.SpecFlowPlugin/Orangebeard.SpecFlowPlugin.csproj
@@ -47,7 +47,7 @@
   </PropertyGroup>
 
   <ItemGroup>
-    <PackageReference Include="Orangebeard.Client" Version="2.1.1" />
+    <PackageReference Include="Orangebeard.Client" Version="2.1.5" />
     <PackageReference Include="SpecFlow" Version="3.9.74" />
   </ItemGroup>
 

--- a/src/Orangebeard.SpecFlowPlugin/Orangebeard.SpecFlowPlugin.csproj
+++ b/src/Orangebeard.SpecFlowPlugin/Orangebeard.SpecFlowPlugin.csproj
@@ -1,9 +1,9 @@
-<Project Sdk="Microsoft.NET.Sdk">
+﻿<Project Sdk="Microsoft.NET.Sdk">
 
   <PropertyGroup>
     <TargetFrameworks>net462;netstandard2.1;netcoreapp3.1</TargetFrameworks>
     <PackageId>Orangebeard.SpecFlow</PackageId>
-    <Version>1.0.1.0</Version>
+    <Version>1.1.0.0</Version>
     
     <Description>Plugin to output SpecFlow test logging into Orangebeard</Description>
     <Authors>Team Soju</Authors>
@@ -17,9 +17,33 @@
 
     <AllowedOutputExtensionsInPackageBuildOutputFolder>$(AllowedOutputExtensionsInPackageBuildOutputFolder);.pdb</AllowedOutputExtensionsInPackageBuildOutputFolder>
 
-    <Company>Oramgebeard.io</Company>
+    <Company>Orangebeard.io</Company>
 
     <GeneratePackageOnBuild>true</GeneratePackageOnBuild>
+  </PropertyGroup>
+
+  <PropertyGroup Condition="'$(Configuration)|$(TargetFramework)|$(Platform)'=='Debug|net462|AnyCPU'">
+    <DebugType>full</DebugType>
+  </PropertyGroup>
+
+  <PropertyGroup Condition="'$(Configuration)|$(TargetFramework)|$(Platform)'=='Release|net462|AnyCPU'">
+    <DebugType>full</DebugType>
+  </PropertyGroup>
+
+  <PropertyGroup Condition="'$(Configuration)|$(TargetFramework)|$(Platform)'=='Debug|netstandard2.1|AnyCPU'">
+    <DebugType>full</DebugType>
+  </PropertyGroup>
+
+  <PropertyGroup Condition="'$(Configuration)|$(TargetFramework)|$(Platform)'=='Release|netstandard2.1|AnyCPU'">
+    <DebugType>full</DebugType>
+  </PropertyGroup>
+
+  <PropertyGroup Condition="'$(Configuration)|$(TargetFramework)|$(Platform)'=='Debug|netcoreapp3.1|AnyCPU'">
+    <DebugType>full</DebugType>
+  </PropertyGroup>
+
+  <PropertyGroup Condition="'$(Configuration)|$(TargetFramework)|$(Platform)'=='Release|netcoreapp3.1|AnyCPU'">
+    <DebugType>full</DebugType>
   </PropertyGroup>
 
   <ItemGroup>

--- a/src/Orangebeard.SpecFlowPlugin/OrangebeardOutputHelper.cs
+++ b/src/Orangebeard.SpecFlowPlugin/OrangebeardOutputHelper.cs
@@ -1,0 +1,122 @@
+﻿using Orangebeard.Client.Abstractions.Models;
+using Orangebeard.Client.Abstractions.Requests;
+using Orangebeard.Shared.Reporter;
+using Orangebeard.SpecFlowPlugin.Attachment;
+using Orangebeard.SpecFlowPlugin.LogHandler;
+using System;
+using System.Collections.Generic;
+using System.IO;
+using System.Text.RegularExpressions;
+using TechTalk.SpecFlow.Events;
+using TechTalk.SpecFlow.Infrastructure;
+using TechTalk.SpecFlow.Tracing;
+
+namespace Orangebeard.SpecFlowPlugin
+{
+    public class OrangebeardOutputHelper : ISpecFlowOutputHelper
+    {
+        private readonly SpecFlowOutputHelper _baseHelper;
+
+        private const string FILE_PATH_PATTERN = @"((((?<!\w)[A-Z,a-z]:)|(\.{0,2}\\))([^\b%\/\|:\n<>""']*))";
+
+        public OrangebeardOutputHelper(ITestThreadExecutionEventPublisher testThreadExecutionEventPublisher, ITraceListener traceListener, ISpecFlowAttachmentHandler specFlowAttachmentHandler)
+        {
+            _baseHelper = new SpecFlowOutputHelper(testThreadExecutionEventPublisher, traceListener, specFlowAttachmentHandler);   
+        }
+
+        public void AddAttachment(string filePath)
+        {
+            SendAttachment(GetAttachmentFileFromPath(filePath), null);
+            _baseHelper.AddAttachment(filePath);
+        }
+
+        public void WriteLine(string text)
+        {
+            SendLog(text);
+            _baseHelper.WriteLine(text);
+        }
+
+        public void WriteLine(string format, params object[] args)
+        {
+            SendLog(string.Format(format, args));
+            _baseHelper.WriteLine(format, args);
+        }
+
+        private void SendLog(string message)
+        {
+            Match match = Regex.Match(message, FILE_PATH_PATTERN);
+            if (match.Success) //Look only at first match, as we support max 1 attachment per log entry
+            {
+                string filePath = match.Value;
+                if (!Path.IsPathRooted(filePath))
+                {
+                    filePath = Directory.GetCurrentDirectory() + Path.DirectorySeparatorChar + filePath;
+                }
+                SendAttachment(GetAttachmentFileFromPath(filePath), message);               
+            }
+            else
+            {
+                SendLog(message, LogLevel.Info);
+            }             
+        }
+
+        private void SendLog(string message, LogLevel level)
+        {
+            GetCurrentReporter().Log(new CreateLogItemRequest
+            {
+                Level = level,
+                Text = message,
+                Format = LogFormat.MARKDOWN,
+                Time = DateTime.UtcNow
+            });
+        }
+
+        private void SendAttachment(SpecFlowAttachmentFile attachment, string logMessage)
+        {
+            if (attachment != null)
+            {
+                GetCurrentReporter().Log(new CreateLogItemRequest
+                {
+                    Time = DateTime.UtcNow,
+                    Level = LogLevel.Info,
+                    Text = logMessage ?? "[Attachment]: " + attachment.FileName,
+                    Format = LogFormat.PLAIN_TEXT,
+                    Attach = new LogItemAttach(attachment.MimeType, attachment.Data) { Name = attachment.FileName }
+                });
+            }
+        }
+
+        private SpecFlowAttachmentFile GetAttachmentFileFromPath(string filePath)
+        {
+            try
+            {
+                return new SpecFlowAttachmentFile(
+                    Orangebeard.Shared.MimeTypes.MimeTypeMap.GetMimeType(Path.GetExtension(filePath)),
+                    Path.GetFileName(filePath),
+                    File.ReadAllBytes(filePath));            
+            } catch (Exception e)
+            {
+                SendLog($"\r\nFailed to attach {filePath} ({e.Message})", LogLevel.Warning);
+                return null;
+            }
+        }
+
+        private ITestReporter GetCurrentReporter()
+        {
+            var reporter = OrangebeardAddIn.GetStepTestReporter(ContextAwareLogHandler.ActiveStepContext);
+
+            if (reporter == null)
+            {
+                reporter = OrangebeardAddIn.GetScenarioTestReporter(ContextAwareLogHandler.ActiveScenarioContext);
+            }
+
+            if (reporter == null)
+            {
+                reporter = OrangebeardAddIn.GetFeatureTestReporter(ContextAwareLogHandler.ActiveFeatureContext);
+            }
+          
+            return reporter;
+        }
+
+    }
+}

--- a/src/Orangebeard.SpecFlowPlugin/Plugin.cs
+++ b/src/Orangebeard.SpecFlowPlugin/Plugin.cs
@@ -36,11 +36,13 @@ namespace Orangebeard.SpecFlowPlugin
                 {
                     e.SpecFlowConfiguration.AdditionalStepAssemblies.Add("Orangebeard.SpecFlowPlugin");
                     e.ObjectContainer.RegisterTypeAs<SafeBindingInvoker, IBindingInvoker>();
+                    e.ObjectContainer.RegisterTypeAs<OrangebeardOutputHelper, ISpecFlowOutputHelper>();
                 };
 
                 runtimePluginEvents.CustomizeScenarioDependencies += (sender, e) =>
                 {
                     e.ObjectContainer.RegisterTypeAs<SkippedStepsHandler, ISkippedStepHandler>();
+                    e.ObjectContainer.RegisterTypeAs<OrangebeardOutputHelper, ISpecFlowOutputHelper>();
                 };
             }
         }


### PR DESCRIPTION
- Add support for specflow's OutputHelper
- Append args to test names to uniquely identify test cases 
- Add attachment support from outputhelper
- Log errors on the actual Scenario level